### PR TITLE
A proposed change to the way MessageHandler delegates are created.

### DIFF
--- a/UnityPackage/Runtime/Client.cs
+++ b/UnityPackage/Runtime/Client.cs
@@ -116,7 +116,10 @@ namespace RiptideNetworking
                     Action<ushort, Message> serverMessageHandler = (Action<ushort, Message>)Delegate.CreateDelegate(typeof(Action<ushort, Message>), methods[i], false);
                     if (serverMessageHandler == null)
                         throw new Exception($"'{methods[i].DeclaringType}.{methods[i].Name}' doesn't match any acceptable message handler method signatures, double-check its parameters!");
-                    clientMessageHandler = (MessageHandler)((message) => serverMessageHandler(0, message));
+                    if (attribute.ClientServerIndependent)
+                        clientMessageHandler = (MessageHandler)((message) => serverMessageHandler(0, message));
+                    else
+                        continue;
                 }
                 // It's a message handler for Client instances
                 if (messageHandlers.ContainsKey(attribute.MessageId))

--- a/UnityPackage/Runtime/MessageHandlerAttribute.cs
+++ b/UnityPackage/Runtime/MessageHandlerAttribute.cs
@@ -13,20 +13,26 @@ namespace RiptideNetworking
     {
         /// <inheritdoc cref="messageId"/>
         public ushort MessageId => messageId;
+        /// <inheritdoc cref="clientServerIndependent"/>
+        public bool ClientServerIndependent => clientServerIndependent;
         /// <inheritdoc cref="groupId"/>
         public byte GroupId => groupId;
 
         /// <summary>The ID of the message type that this method is meant to handle.</summary>
         private readonly ushort messageId;
+        /// <summary>If set to true, the client/server should accept this method regardless of what parameters it has.</summary>
+        private readonly bool clientServerIndependent;
         /// <summary>The ID of the group of message handlers this method belongs to.</summary>
         private readonly byte groupId;
 
-        /// <summary>Initializes a new instance of the <see cref="MessageHandlerAttribute"/> class with the <paramref name="messageId"/> and <paramref name="groupId"/> values.</summary>
+        /// <summary>Initializes a new instance of the <see cref="MessageHandlerAttribute"/> class with the <paramref name="messageId"/> and <paramref name="groupId"/> and <paramref name="clientServerIndependent"/> values.</summary>
         /// <param name="messageId">The ID of the message type that this method is meant to handle.</param>
+        /// <param name="clientServerIndependent">If set to true, the client/server should accept this method regardless of what parameters it has.</param>
         /// <param name="groupId">The ID of the group of message handlers this method belongs to.</param>
-        public MessageHandlerAttribute(ushort messageId, byte groupId = 0)
+        public MessageHandlerAttribute(ushort messageId, bool clientServerIndependent = false, byte groupId = 0)
         {
             this.messageId = messageId;
+            this.clientServerIndependent = clientServerIndependent;
             this.groupId = groupId;
         }
     }

--- a/UnityPackage/Runtime/Server.cs
+++ b/UnityPackage/Runtime/Server.cs
@@ -97,25 +97,23 @@ namespace RiptideNetworking
                 if (!methods[i].IsStatic)
                     throw new Exception($"Message handler methods should be static, but '{methods[i].DeclaringType}.{methods[i].Name}' is an instance method!");
 
-                Delegate clientMessageHandler = Delegate.CreateDelegate(typeof(MessageHandler), methods[i], false);
-                if (clientMessageHandler != null)
-                {
-                    // It's a message handler for Server instances
-                    if (messageHandlers.ContainsKey(attribute.MessageId))
-                    {
-                        MethodInfo otherMethodWithId = messageHandlers[attribute.MessageId].GetMethodInfo();
-                        throw new Exception($"Server-side message handler methods '{methods[i].DeclaringType}.{methods[i].Name}' and '{otherMethodWithId.DeclaringType}.{otherMethodWithId.Name}' are both set to handle messages with ID {attribute.MessageId}! Only one handler method is allowed per message ID!");
-                    }
-                    else
-                        messageHandlers.Add(attribute.MessageId, (MessageHandler)clientMessageHandler);
-                }
-                else
+                Delegate serverMessageHandler = Delegate.CreateDelegate(typeof(MessageHandler), methods[i], false);
+                if (serverMessageHandler == null)
                 {
                     // It's not a message handler for Server instances, but it might be one for Client instances
-                    Delegate serverMessageHandler = Delegate.CreateDelegate(typeof(Client.MessageHandler), methods[i], false);
-                    if (serverMessageHandler == null)
+                    Action<Message> clientMessageHandler = (Action<Message>)Delegate.CreateDelegate(typeof(Action<Message>), methods[i], false);
+                    if (clientMessageHandler == null)
                         throw new Exception($"'{methods[i].DeclaringType}.{methods[i].Name}' doesn't match any acceptable message handler method signatures, double-check its parameters!");
+                    serverMessageHandler = (MessageHandler)((clientId, message) => clientMessageHandler(message));
                 }
+                // It's a message handler for Server instances
+                if (messageHandlers.ContainsKey(attribute.MessageId))
+                {
+                    MethodInfo otherMethodWithId = messageHandlers[attribute.MessageId].GetMethodInfo();
+                    throw new Exception($"Server-side message handler methods '{methods[i].DeclaringType}.{methods[i].Name}' and '{otherMethodWithId.DeclaringType}.{otherMethodWithId.Name}' are both set to handle messages with ID {attribute.MessageId}! Only one handler method is allowed per message ID!");
+                }
+                else
+                    messageHandlers.Add(attribute.MessageId, (MessageHandler)serverMessageHandler);
             }
         }
 

--- a/UnityPackage/Runtime/Server.cs
+++ b/UnityPackage/Runtime/Server.cs
@@ -104,7 +104,10 @@ namespace RiptideNetworking
                     Action<Message> clientMessageHandler = (Action<Message>)Delegate.CreateDelegate(typeof(Action<Message>), methods[i], false);
                     if (clientMessageHandler == null)
                         throw new Exception($"'{methods[i].DeclaringType}.{methods[i].Name}' doesn't match any acceptable message handler method signatures, double-check its parameters!");
-                    serverMessageHandler = (MessageHandler)((clientId, message) => clientMessageHandler(message));
+                    if (attribute.ClientServerIndependent)
+                        serverMessageHandler = (MessageHandler)((clientId, message) => clientMessageHandler(message));
+                    else
+                        continue;
                 }
                 // It's a message handler for Server instances
                 if (messageHandlers.ContainsKey(attribute.MessageId))


### PR DESCRIPTION
 so I started to setup a project with a playerhostet server, and there is one little thing I think you could change to improve the quality of life when doing this kinds of projects. In order to keep my code clean in many cases I want the same behaviour when receiving a message as a server and as a client. However, since the MessageHandler Delegates are not the same for clients and servers, I will always need two static functions. One for the server (with ushort fromClientId) and one for the client (Without the ushort). It is just a small thing, but I think it would be simpler if the ushort weren't necessary but optional on servers.

With these changes, when the server script finds a clientMessageHandler or vice versa, It just gets converted using a Generic Action<> and a lambda expression:

serverMessageHandler = (MessageHandler)((clientId, message) => clientMessageHandler(message));

(Also for whatever reason the serverMessageHandler variable in the Server.cs script was named clientMessageHandler, I also changed that (just to prevent confusion))