### PR TITLE
Disable name violation on converters

### DIFF
--- a/RiptideNetworking/RiptideNetworking/Utils/RiptideConverter.cs
+++ b/RiptideNetworking/RiptideNetworking/Utils/RiptideConverter.cs
@@ -324,6 +324,7 @@ namespace RiptideNetworking.Utils
         #endregion
     }
 
+#pragma warning disable IDE1006
     [StructLayout(LayoutKind.Explicit)]
     internal struct FloatConverter
     {
@@ -349,4 +350,5 @@ namespace RiptideNetworking.Utils
 
         [FieldOffset(0)] public double doubleValue;
     }
+#pragma warning restore IDE1006
 }


### PR DESCRIPTION
Disable name violation on FloatConverter and DoubleConverter

![image](https://user-images.githubusercontent.com/14964651/152382019-f4a50fcf-908c-43ec-9e0b-5bff1512f880.png)
