### PR TITLE
Allow to use Enums in MessageHandlerAttribute

### DIFF
--- a/RiptideNetworking/RiptideNetworking/MessageHandlerAttribute.cs
+++ b/RiptideNetworking/RiptideNetworking/MessageHandlerAttribute.cs
@@ -46,5 +46,13 @@ namespace Riptide
             MessageId = messageId;
             GroupId = groupId;
         }
+
+        /// <inheritdoc cref="MessageHandlerAttribute(ushort, byte)"/>
+        /// <remarks>NOTE: <paramref name="messageId"/> will be cast to a <see cref="ushort"/>. You should ensure that its value never exceeds that of <see cref="ushort.MaxValue"/>, otherwise you'll encounter unexpected behaviour when handling messages.</remarks>
+        public MessageHandlerAttribute(object messageId, byte groupId = 0)
+        {
+            MessageId = (ushort)messageId;
+            GroupId = groupId;
+        }
     }
 }


### PR DESCRIPTION
This change allow to use plain Enums in the attribute rather than forcing users to manually cast each attribute parameter

Old :
`[MessageHandler((ushort)ServerToClientId.sync)]`

New :
`[MessageHandler(ServerToClientId.sync)]`

Potential issue :

Because C# do not allow Enums as attributes parameter, we have to rely on "Object" as parameter. This approach allow the user to pass any parameter to the Attribute, including string, which would cause an InvalidCastException at runtime.

The error being pretty clear thanks to the full stack trace pointing on the specific attribute, happening at start time (when attributes are generated) and being easily both fixable & avoidable, it appear to me that the code clarity gain is important enough to justify this flaw.
